### PR TITLE
Increasing build timeout

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,2 +1,3 @@
 languageCode: "en-us"
 title: "Coding to Learn and Create"
+timeout: 30000


### PR DESCRIPTION
The VM or container where Netlify is running the hugo build process might not have enough resources to finish the new image processing for our blog posts. Increasing the build timeout to see if all the pages get generated.